### PR TITLE
JBOSGI-782: VFS30 test JAR Manifests absent with JDK 1.7

### DIFF
--- a/vfs30/src/test/java/org/jboss/test/osgi/vfs30/SimpleVFS30TestCase.java
+++ b/vfs30/src/test/java/org/jboss/test/osgi/vfs30/SimpleVFS30TestCase.java
@@ -93,7 +93,6 @@ public class SimpleVFS30TestCase {
                 ShrinkWrap.create(JavaArchive.class, "example simple with "
                         + "\u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0437"
                         + "\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u043C\u0438.jar");
-        archive.addClass(SimpleActivator.class);
         archive.setManifest(new Asset() {
             public InputStream openStream() {
                 String path = "/simple/" + JarFile.MANIFEST_NAME;
@@ -105,6 +104,7 @@ public class SimpleVFS30TestCase {
                 }
             }
         });
+        archive.addClass(SimpleActivator.class);
         file = toFile(archive);
     }
 


### PR DESCRIPTION
The manifest entries are ordered with shrinkwrap so manifest has to be set first.
